### PR TITLE
Improve usability in groups

### DIFF
--- a/src/main/java/jenkinsci/plugins/telegrambot/telegram/TelegramBot.java
+++ b/src/main/java/jenkinsci/plugins/telegrambot/telegram/TelegramBot.java
@@ -118,10 +118,7 @@ public class TelegramBot extends TelegramLongPollingCommandBot {
     }
 
     @Override
-    public void processNonCommandUpdate(Update update) {
-        Long chatId = update.getMessage().getChatId();
-        sendMessage(chatId, GlobalConfiguration.getInstance().getBotStrings().get("message.noncommand"));
-    }
+    public void processNonCommandUpdate(Update update) {}
 
     @Override
     public String getBotToken() {

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -21,6 +21,5 @@ message.sub.success=You've successfully subscribed. Please, wait for approval fr
 message.sub.alreadysub=You've already subscribed.
 message.unsub.success=You've successfully unsubscribed.
 message.unsub.alreadyunsub=You've already unsubscribed.
-message.noncommand=Use \/help command to get the help message.
 message.approved=You've been approved by Jenkins admin.
 message.unapproved=You've been unapproved by Jenkins admin.


### PR DESCRIPTION
Hi!

This plugin is really awesome except it spams with help message in group chats. Because of autoreply to every unrecognized message. I don't think this behavior was any usefull anyway since it's not that hard to remember basic plugin commands.

So I suppressed /help messages, built `.hpi` package, all seems to work fine.