### PR TITLE
Improve subscriber text representation on Jenkins settings page

### DIFF
--- a/src/main/java/jenkinsci/plugins/telegrambot/telegram/commands/SubCommand.java
+++ b/src/main/java/jenkinsci/plugins/telegrambot/telegram/commands/SubCommand.java
@@ -22,7 +22,7 @@ public class SubCommand extends AbstractBotCommand {
         String ans;
 
         Long id = chat.getId();
-        String name = chat.isUserChat() ? user.getUserName() : chat.getTitle();
+        String name = chat.isUserChat() ? user.toString() : chat.toString();
 
         boolean isSubscribed = subscribers.isSubscribed(id);
 

--- a/src/main/resources/jenkinsci/plugins/telegrambot/TelegramBotGlobalConfiguration/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/telegrambot/TelegramBotGlobalConfiguration/config.jelly
@@ -50,7 +50,7 @@
                                 <div class="t1">
                                 </div>
                                 <div class="t2">
-                                    <b>Name</b>
+                                    <b>User/Chat</b>
                                 </div>
                                 <div class="t3">
                                     <b>ID</b>


### PR DESCRIPTION
In case the subscribing telegram user has no username set, the text shown was not really helpful. The commit adds more details that can help in identifying the user from the text.