### PR TITLE
Fix storing format of botToken field

### DIFF
--- a/src/main/java/jenkinsci/plugins/telegrambot/TelegramBotGlobalConfiguration.java
+++ b/src/main/java/jenkinsci/plugins/telegrambot/TelegramBotGlobalConfiguration.java
@@ -3,6 +3,7 @@ package jenkinsci.plugins.telegrambot;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.model.GlobalConfiguration;
 import jenkinsci.plugins.telegrambot.telegram.TelegramBotRunner;
 import jenkinsci.plugins.telegrambot.users.Subscribers;
@@ -125,7 +126,7 @@ public class TelegramBotGlobalConfiguration extends GlobalConfiguration {
     }
 
     public void setBotToken(String botToken) {
-        this.botToken = botToken;
+        this.botToken = Secret.fromString(botToken).getPlainText();
     }
 
     public String getBotName() {


### PR DESCRIPTION
Jenkins **<f:password>** field encrypts value before showing it in the browser.
Due to this the plugin saves encrypted value in the storage and TelegramBot tries
to use it when calls the API, that lead to following exception:

```
2020-09-27 05:14:30.252+0000 [id=3457]  SEVERE  j.p.t.telegram.TelegramBot#sendMessage: Error while sending the message
java.net.URISyntaxException: Illegal character in path at index 28: https://api.telegram.org/bot{...==}/sendmessage
        at java.base/java.net.URI$Parser.fail(URI.java:2915)
        at java.base/java.net.URI$Parser.checkChars(URI.java:3086)
        at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3168)
        at java.base/java.net.URI$Parser.parse(URI.java:3116)
        at java.base/java.net.URI.<init>(URI.java:600)
        at java.base/java.net.URI.create(URI.java:881)
Caused: java.lang.IllegalArgumentException: Illegal character in path at index 28: https://api.telegram.org/bot{...==}/sendmessage
        at java.base/java.net.URI.create(URI.java:883)
        at org.apache.http.client.methods.HttpPost.<init>(HttpPost.java:73)
        at jenkinsci.plugins.telegrambot.telegram.TelegramBot.configuredHttpPost(TelegramBot.java:174)
        at jenkinsci.plugins.telegrambot.telegram.TelegramBot.sendMethodRequest(TelegramBot.java:250)
        at jenkinsci.plugins.telegrambot.telegram.TelegramBot.sendApiMethodWithProxy(TelegramBot.java:238)
        at jenkinsci.plugins.telegrambot.telegram.TelegramBot.execute(TelegramBot.java:170)
        at jenkinsci.plugins.telegrambot.telegram.TelegramBot.sendMessage(TelegramBot.java:81)
        at jenkinsci.plugins.telegrambot.telegram.TelegramBot.sendMessage(TelegramBot.java:111)
        at jenkinsci.plugins.telegrambot.TelegramBotMessager.perform(TelegramBotMessager.java:71)
        at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
        ...
```

This change fixes that bug, now we check if botToken is encrypted and decrypt it before storing.