### PR TITLE
FIXED c.f.j.c.JsonParseException: Numeric value out of range of int

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,13 @@
 
         <!--Maven plugins-->
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
-        <jacoco.version>0.7.4.201502262128</jacoco.version>
+        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <jacoco.version>0.8.5</jacoco.version>
 
         <!--Libraries-->
-        <slf4j.version>1.7.29</slf4j.version>
-        <telegrambots.version>4.6</telegrambots.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <telegrambots.version>5.5.0</telegrambots.version>
         <jenkins.plugins.job-dsl.version>1.68</jenkins.plugins.job-dsl.version>
         <jenkins.plugins.structs.version>1.13</jenkins.plugins.structs.version>
         <jenkins.plugins.token-macro.version>2.3</jenkins.plugins.token-macro.version>
@@ -147,6 +148,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/jenkinsci/plugins/telegrambot/telegram/TelegramBot.java
+++ b/src/main/java/jenkinsci/plugins/telegrambot/telegram/TelegramBot.java
@@ -53,11 +53,11 @@ public class TelegramBot extends TelegramLongPollingCommandBot {
     private final String token;
     private volatile CloseableHttpClient httpclient;
     private volatile RequestConfig requestConfig;
-
+    private final String name;
 
     public TelegramBot(String token, String name) {
-        super(name);
         this.token = token;
+        this.name = name;
 
         initializeProxy();
 
@@ -260,5 +260,10 @@ public class TelegramBot extends TelegramLongPollingCommandBot {
             BufferedHttpEntity bufferedHttpEntity = new BufferedHttpEntity(httpEntity);
             return EntityUtils.toString(bufferedHttpEntity, StandardCharsets.UTF_8);
         }
+    }
+
+    @Override
+    public String getBotUsername() {
+        return name;
     }
 }

--- a/src/main/java/jenkinsci/plugins/telegrambot/telegram/TelegramBotRunner.java
+++ b/src/main/java/jenkinsci/plugins/telegrambot/telegram/TelegramBotRunner.java
@@ -2,10 +2,11 @@ package jenkinsci.plugins.telegrambot.telegram;
 
 import jenkins.model.GlobalConfiguration;
 import jenkinsci.plugins.telegrambot.TelegramBotGlobalConfiguration;
-import org.telegram.telegrambots.ApiContextInitializer;
+
 import org.telegram.telegrambots.meta.TelegramBotsApi;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.BotSession;
+import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -17,7 +18,7 @@ public class TelegramBotRunner {
 
     private static final Logger LOG = Logger.getLogger(TelegramBot.class.getName());
 
-    private final TelegramBotsApi api = new TelegramBotsApi();
+    private final TelegramBotsApi api;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private TelegramBot bot;
@@ -26,14 +27,17 @@ public class TelegramBotRunner {
     private String botToken;
     private String botName;
 
-
-    static {
-        ApiContextInitializer.init();
+    public TelegramBotRunner() throws TelegramApiException {
+        api = new TelegramBotsApi(DefaultBotSession.class);
     }
 
     public synchronized static TelegramBotRunner getInstance() {
         if (instance == null) {
-            instance = new TelegramBotRunner();
+            try {
+                instance = new TelegramBotRunner();
+            } catch (TelegramApiException e) {
+                LOG.log(Level.SEVERE, "Telegram API error", e);
+            }
         }
         return instance;
     }
@@ -70,7 +74,7 @@ public class TelegramBotRunner {
         try {
             botSession = api.registerBot(bot);
             LOG.log(Level.INFO, "New bot session was registered");
-        } catch (TelegramApiRequestException e) {
+        } catch (TelegramApiException e) {
             LOG.log(Level.SEVERE, "Telegram API error", e);
         }
     }


### PR DESCRIPTION
I'm not Java developer, so this pull request is more like an example.

**Problem**: My UserId no longer fits into Int
```
2021-12-27 15:21:18.778+0000 [id=89]    SEVERE  o.t.t.meta.logging.BotLogger#severe: BOTSESSION
com.fasterxml.jackson.core.JsonParseException: Numeric value (********) out of range of int
 at [Source: (String)"{"ok":true,"result":[{"update_id":26962324,
"message":{"message_id":71,"from":{"id":********,"is_bot":false,"first_name":"********","language_code":"ru"},"chat":{"id":********,"first_name":"********","type":"private"},"date":1640586660,"text":"/start","entities":[{"offset":0,"length":6,"type":"bot_command"}]}},{"update_id":26962325,
"message":{"message_id":72,"from":{"id":********,"is_bot":false,"first_name":"********","language_code":"ru"},"chat":{"id":********,"first_name":"********","type":"private"}"[truncated 1526 chars]; line: 2, column: 51]
        at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1804)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:693)
................................................
```

It is fixed in the version TelegramBots API 5.1:
https://github.com/rubenlagus/TelegramBots/commit/6653ffe9379bac874bbdff63e011f2c825555494#diff-2d34b08ac04313d2bb1afd92284a4146936a365ae6c8f8a614523420fdcf1848

I laid out the changes in this pull request with which the plugin was compiled and worked. 